### PR TITLE
Add Authorization HTTP header check

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/webhookstep/RegisterWebhookExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/RegisterWebhookExecution.java
@@ -6,9 +6,15 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 public class RegisterWebhookExecution extends AbstractSynchronousStepExecution<WebhookToken> {
 
     private static final long serialVersionUID = -6718328636399912927L;
+    private final String authToken;
 
-    public RegisterWebhookExecution(StepContext context) {
+    public RegisterWebhookExecution(StepContext context, String authToken) {
         super(context);
+        this.authToken = authToken;
+    }
+
+    public String getAuthToken() {
+        return this.authToken;
     }
 
     @Override
@@ -22,6 +28,9 @@ public class RegisterWebhookExecution extends AbstractSynchronousStepExecution<W
         java.net.URI relative = new java.net.URI("webhook-step/" + token);
         java.net.URI path = baseUri.resolve(relative);
 
-        return new WebhookToken(token, path.toString());
+        WebhookToken hook = new WebhookToken(
+            token, path.toString(), this.authToken);
+        WebhookRootAction.registerAuthToken(hook);
+        return hook;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/RegisterWebhookStep.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/RegisterWebhookStep.java
@@ -10,14 +10,16 @@ import hudson.Extension;
 
 public class RegisterWebhookStep extends Step {
 
-    @DataBoundConstructor
-    public RegisterWebhookStep() {
+    private final String authToken;
 
+    @DataBoundConstructor
+    public RegisterWebhookStep(String authToken) {
+        this.authToken = authToken;
     }
 
     @Override
     public StepExecution start(StepContext context) throws Exception {
-        return new RegisterWebhookExecution(context);
+        return new RegisterWebhookExecution(context, this.authToken);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookRootAction.java
@@ -23,6 +23,7 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
 
     private static final HashMap<String, WaitForWebhookExecution> webhooks = new HashMap<>();
     private static final HashMap<String, String> alreadyPosted = new HashMap<>();
+    private static final HashMap<String, String> authTokens = new HashMap<>();
 
     @Override
     public String getDisplayName() {
@@ -41,6 +42,24 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
 
     public void doDynamic(StaplerRequest request, StaplerResponse response) {
         String token = request.getOriginalRestOfPath().substring(1); //Strip leading slash
+        String authHeader = request.getHeader("Authorization");
+        String authToken;
+
+        synchronized (authTokens) {
+            authToken = authTokens.get(token);
+        }
+
+        if (authToken != null) {
+            if (!authToken.equals(authHeader)) {
+                response.setHeader("Result", "Unauthorized");
+                response.setStatus(403);
+                return;
+            }
+        } else if (authHeader != null) {
+            Logger.getLogger(WebhookRootAction.class.getName())
+                .warning("Unexpected Authorization header for Webhook " +
+                         token);
+        }
 
         CharBuffer dest = CharBuffer.allocate(1024);
         StringBuffer content = new StringBuffer();
@@ -63,7 +82,7 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
         synchronized (webhooks) {
             exec = webhooks.remove(token);
             if (exec == null) {
-                //pipeline has not yet waited on webhook, add an entry to track 
+                //pipeline has not yet waited on webhook, add an entry to track
                 //that it was already triggered
                 alreadyPosted.put(token, content.toString());
             }
@@ -76,7 +95,12 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
         } else {
             response.setStatus(202);
         }
+    }
 
+    public static void registerAuthToken(WebhookToken hook) {
+        synchronized (authTokens) {
+            authTokens.put(hook.getToken(), hook.getAuthToken());
+        }
     }
 
     //Returns null when the webhook has been registered, the content when the webhook has already been called
@@ -98,6 +122,9 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
                 .info("Deregistering webhook with token " + exec.getToken());
         synchronized (webhooks) {
             webhooks.remove(exec.getToken());
+        }
+        synchronized (authTokens) {
+            authTokens.remove(exec.getToken());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookToken.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookToken.java
@@ -4,24 +4,30 @@ import java.io.Serializable;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 public class WebhookToken implements Serializable {
-    
+
     private static final long serialVersionUID = 1;
-    
+
     private final String token;
     private final String url;
-    
-    public WebhookToken(String token, String url) {
+    private final String authToken;
+
+    public WebhookToken(String token, String url, String authToken) {
         this.token = token;
         this.url = url;
+        this.authToken = authToken;
     }
-    
+
     @Whitelisted
     public String getToken() {
         return token;
     }
-    
+
     @Whitelisted
     public String getURL() {
         return url;
+    }
+
+    public String getAuthToken() {
+        return this.authToken;
     }
 }


### PR DESCRIPTION
Add an optional authorization string when registering the Webhook.  If
used, discard any incoming request that does not have a matching
Authorization header.  Otherwise, keep the same behaviour as before.
Log a warning if an Authorization header is received but none was
expected.

This is particularly useful when the callback URL is made public
(e.g. LAVA job definition) and when using an encrypted communication.
The Authorization header would typically be a token stored both in the
Jenkins secrets and in the remote end, and never be transferred in
clear.  Some application specific mechanism will be used to enable the
remote end to pick the correct token, for example by first sending a
token identifier when setting up the remote callback.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>