### PR TITLE
Fix data corruption when reading request payload

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookRootAction.java
@@ -46,10 +46,13 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
         StringBuffer content = new StringBuffer();
         try {
             BufferedReader reader = request.getReader();
+            int len;
 
-            while (reader.read(dest) > 0) {
+            while ((len = reader.read(dest)) > 0) {
                 dest.rewind();
+                dest.limit(len);
                 content.append(dest.toString());
+                dest.limit(dest.capacity());
             }
         } catch (IOException e) {
             response.setStatus(400);
@@ -63,7 +66,7 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
         synchronized (webhooks) {
             exec = webhooks.remove(token);
             if (exec == null) {
-                //pipeline has not yet waited on webhook, add an entry to track 
+                //pipeline has not yet waited on webhook, add an entry to track
                 //that it was already triggered
                 alreadyPosted.put(token, content.toString());
             }


### PR DESCRIPTION
The character buffer used to read the payload data is always being
fully appended to the output data even when the number of bytes read
was less than its capacity.  This results in trailing characters from
the penultimate read left in the buffer to be copied again at the end
of the last read.  This issue can only be seen when the payload is
over 1024 bytes as this is the size of the buffer.

Fix this by setting the character buffer limit to the number of
characters actually read before appending the data to the output.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>