### PR TITLE
chore: enable full CD

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -4,9 +4,9 @@ name: cd
 on:
   workflow_dispatch:
   # Commenting out to deploy explicitly (not on every push on master)
-  # check_run:
-  #   types:
-  #     - completed
+  check_run:
+    types:
+      - completed
 
 jobs:
   validate:


### PR DESCRIPTION
Plugin will now be released automatically when pushing  a commit or a tag to the master branch.
