### PR TITLE
Fix URL getter to allow property access

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and waits for a user to call it:
 ```
 hook = registerWebhook()
 
-echo "Waiting for POST to ${hook.getURL()}"
+echo "Waiting for POST to ${hook.url}"
 
 data = waitForWebhook hook
 echo "Webhook called with data: ${data}"

--- a/examples/declarative_pipeline
+++ b/examples/declarative_pipeline
@@ -14,7 +14,7 @@ pipeline {
             steps {
                 script {
                     hook = registerWebhook()
-                    callbackURL = hook.getURL()
+                    callbackURL = hook.url
                     
                     // Call a remote system to start execution, passing the callback url
                     //sh "curl -X POST -H 'Content-Type: application/json' -d '{\"callback\":\"${callbackURL}"}' http://httpbin.org/post"

--- a/examples/declarative_withAuthToken
+++ b/examples/declarative_withAuthToken
@@ -16,7 +16,7 @@ pipeline {
                     withCredentials([string(credentialsId: 'webhook_secret', variable: 'SECRET')]) { 
 
                         hook = registerWebhook(token: 'test-webhook', authToken: SECRET)
-                        callbackURL = hook.getURL()
+                        callbackURL = hook.url
                         sh "echo ${callbackURL}"
 
 

--- a/examples/scripted_pipeline
+++ b/examples/scripted_pipeline
@@ -6,7 +6,7 @@ node {
     stage('waiting') {
         hook = registerWebhook()
         
-        echo "Waiting for POST to ${hook.getURL()}"        
+        echo "Waiting for POST to ${hook.url}"
         data = waitForWebhook hook
         
         echo "Webhook called with data: ${data}"

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookToken.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookToken.java
@@ -26,6 +26,11 @@ public class WebhookToken implements Serializable {
 
     @Whitelisted
     public String getURL() {
+        return getUrl();
+    }
+
+    @Whitelisted
+    public String getUrl() {
         return url;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/webhookstep/WaitForWebhookTest.java
+++ b/src/test/java/org/jenkinsci/plugins/webhookstep/WaitForWebhookTest.java
@@ -53,6 +53,29 @@ public class WaitForWebhookTest {
     }
 
     @Test
+    public void testWebhookDataAccess() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "prj");
+
+        String pipelineCode = "def hook = registerWebhook()\n" +
+                "echo \"token_long=${hook.getToken()}\"\n" +
+                "echo \"token_short=${hook.token}\"\n" +
+                "echo \"url_long=${hook.getURL()}\"\n" +
+                "echo \"url_long2=${hook.getUrl()}\"\n" +
+                "echo \"url_short=${hook.url}\"\n";
+
+        p.setDefinition(new CpsFlowDefinition(pipelineCode, true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+
+        j.waitForCompletion(b);
+        j.assertBuildStatus(Result.SUCCESS, b);
+        j.assertLogContains("token_long=", b);
+        j.assertLogContains("token_short=", b);
+        j.assertLogContains("url_long=", b);
+        j.assertLogContains("url_long2=", b);
+        j.assertLogContains("url_short=", b);
+    }
+
+    @Test
     public void testUseCustomToken() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "prj");
 


### PR DESCRIPTION
While it's possible to access `token` as property already, `url` still requires a getter-call:

```groovy
hook.getToken() // OK
hook.token // OK

hook.getURL() // OK
hook.url // Error - RejectedAccessException
```

This PR adds a properly named getter so `hook.url` works too.

##### Discussion

❓ Should `getURL()` get deprecated?

---------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
