### PR TITLE
Deprecate getURL()

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ The log file will thus show `Webhook called with data: OK`.
 
 For illustration, see the [scripted pipeline example](examples/scripted_pipeline).
 
+
+Accessing hook data
+-------------------
+
+- **Token:** `hook.token` / `hook.getToken()`
+- **Url:** `hook.url` / `hook.getUrl()`
+
+###### Deprecation notice:
+
+`getURL()` is *deprecated* and will be removed in a future release.
+
+
 Specifying a fixed webhook name
 -------------------------------
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ Webhook Step Plugin
 ===================
 
 This pipeline plugin provides an easy way to block a build pipeline until an
-external system posts to a webhook. 
-It can be used to integrate long running tasks into a pipeline, without busy waiting. 
+external system posts to a webhook.
+It can be used to integrate long running tasks into a pipeline, without busy waiting.
 
-A typical example is launching a performance test on a dedicated hardware/configuration. 
-When the task completes, it can easily notify the waiting pipeline. 
+A typical example is launching a performance test on a dedicated hardware/configuration.
+When the task completes, it can easily notify the waiting pipeline.
 The webhook payload can be used to provide information like results or other useful data.
 
 
@@ -25,7 +25,7 @@ Using this plugin will usually require 3 steps:
 For example, the following pipeline script writes out the webhook url to the log
 and waits for a user to call it:
 
-```
+```groovy
 hook = registerWebhook()
 
 echo "Waiting for POST to ${hook.url}"
@@ -43,9 +43,9 @@ Waiting for POST to http://localhost:8080/webhook-step/bef13807-a161-4193-ab95-6
 To continue the pipeline, we can post to this url. To do this with curl, execute
 `curl -X POST -d 'OK' http://localhost:8080/webhook-step/bef13807-a161-4193-ab95-6cb974afc71d`.
 
-The blocking `waitForWebhook` call will then complete. 
+The blocking `waitForWebhook` call will then complete.
 The returned data is the posted JSON payload.
-With the above curl example it would be `OK`. 
+With the above curl example it would be `OK`.
 The log file will thus show `Webhook called with data: OK`.
 
 For illustration, see the [scripted pipeline example](examples/scripted_pipeline).
@@ -53,10 +53,10 @@ For illustration, see the [scripted pipeline example](examples/scripted_pipeline
 Specifying a fixed webhook name
 -------------------------------
 
-Instead of letting the plugin generate a unique webhook ID, you can provide a name at creation. 
+Instead of letting the plugin generate a unique webhook ID, you can provide a name at creation.
 Like this: `hook = registerWebhook(token: "my_webhook")`.
 
-The [declarative pipeline example](examples/declarative_pipeline) illustrates this. 
+The [declarative pipeline example](examples/declarative_pipeline) illustrates this.
 
 
 **caveat**: if several job instances use the same token, only the most recent job will trigger.
@@ -64,12 +64,10 @@ The [declarative pipeline example](examples/declarative_pipeline) illustrates th
 
 Securing the webhook with an authentication token
 -------------------------------------------------
-It is possible to specify an authentication token. 
+It is possible to specify an authentication token.
 This token has to be provided in the header of the webhook HTTP POST for the wait to complete.
 
-To avoid secret leakage in the pipeline source code or logfiles, it is strongly advised to use a "secret text" credential. 
+To avoid secret leakage in the pipeline source code or logfiles, it is strongly advised to use a "secret text" credential.
 The [declarative_withAuthToken](examples/declarative_withAuthToken) example illustrates how to use a webhook step authentication token stored as a secret (`webhook_secret`).
 
 To trigger that webhook, the `curl` command would look like: `curl -X POST -d 'OK' -H "Authorization: 123" <JENKINS_URL>/webhook-step/test-webhook`
-
-

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookToken.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookToken.java
@@ -24,6 +24,10 @@ public class WebhookToken implements Serializable {
         return token;
     }
 
+    /**
+     * @deprecated Use {@link #getUrl()} instead.
+     */
+    @Deprecated
     @Whitelisted
     public String getURL() {
         return getUrl();


### PR DESCRIPTION
Deprecate `getURL()` in favour of `getUrl()`, see #54.

----------------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
