### PR TITLE
Make WebhookResponse serializable so that CPS methods can use it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookResponse.java
@@ -1,10 +1,14 @@
 package org.jenkinsci.plugins.webhookstep;
 
+import java.io.Serializable;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 import java.util.Map;
 
-public class WebhookResponse {
+public class WebhookResponse implements Serializable {
+
+    private static final long serialVersionUID = 1;
+
     private final String content;
     private final Map<String, String> headers;
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

In our Jenkins pipelines, we need to have access to both the Webhook response content and the Webhook response headers - because of that, we call `context.waitForWebhook(webhookToken: webhookToken, withHeaders: true)`.

We then store the `WebhookResponse` object in a variable in a CPS-compatible function.

That mostly works, except that sometimes our pipelines fail with `java.io.NotSerializableException: org.jenkinsci.plugins.webhookstep.WebhookResponse`, and we think that our issue would be resolved by making `WebhookResponse` serializable.

Thus, this pull request declares `WebhookResponse` as serializable, similarly to `WebhookToken`.

Regarding tests, I am not sure what kind of tests you would require for that.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
