### PR TITLE
Remove deprecated java.level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/webhook-step-plugin</gitHubRepo>
     <jenkins.version>2.289.1</jenkins.version>
-    <java.level>8</java.level>
     <gitHubRepo>jenkinsci/webhook-step-plugin</gitHubRepo>
   </properties>
 


### PR DESCRIPTION
Removes the [deprecated `java.level`](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40).

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
