### PR TITLE
Reduce log level of root action

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookRootAction.java
@@ -95,7 +95,7 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
         WebhookResponse whResponse = new WebhookResponse(content.toString(), headers);
 
         Logger.getLogger(WebhookRootAction.class.getName())
-                .info("Webhook called with " + token);
+                .fine("Webhook called with " + token);
 
         WaitForWebhookExecution exec;
         synchronized (webhooks) {
@@ -125,7 +125,7 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
     //Returns null when the webhook has been registered, the content when the webhook has already been called
     public static WebhookResponse registerWebhook(WaitForWebhookExecution exec) {
         Logger.getLogger(WebhookRootAction.class.getName())
-                .info("Registering webhook with token " + exec.getToken());
+                .fine("Registering webhook with token " + exec.getToken());
         synchronized (webhooks) {
             if (alreadyPosted.containsKey(exec.getToken())) {
                 return alreadyPosted.remove(exec.getToken());
@@ -138,7 +138,7 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
 
     public static void deregisterWebhook(WaitForWebhookExecution exec) {
         Logger.getLogger(WebhookRootAction.class.getName())
-                .info("Deregistering webhook with token " + exec.getToken());
+                .fine("Deregistering webhook with token " + exec.getToken());
         synchronized (webhooks) {
             webhooks.remove(exec.getToken());
         }


### PR DESCRIPTION
Reduce logging level of root action to remove it from the default Jenkins Log Recorder (UI).

The info level records any webhook step at them moment, which may pile up if many webhooks are used. 

-----------------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
