### PR TITLE
remove hardcoded jenkins version in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ buildPlugin(
     useContainerAgent: true,
     failFast: false,
     configurations: [
-                [platform: 'linux', jdk: '17', jenkins: '2.342'],
+                [platform: 'linux', jdk: '17'],
                 [platform: 'linux', jdk: '11'],
                 [platform: 'windows', jdk: '11'],
             ]


### PR DESCRIPTION
This PR removes the hardcoded Jenkins version when building on JDK 17