### PR TITLE
Exclude json-unit v3 and higher of dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,11 @@ updates:
   - jmMeessen
   labels:
   - dependencies
+  ignore:
+  # from version 3, json-unit dropped support for java 11
+  - dependency-name: "net.javacrumbs.json-unit:json-unit"
+    versions: [">=3.0.0"]
+
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
Exclude json-unit v3 and higher from dependanbot automatic upgrade PR creation.

The V3 version drops support for java11. We are not ready yet to dropt testing on that version.