### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/webhookstep/RegisterWebhookExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/RegisterWebhookExecution.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.webhookstep;
 
 import hudson.util.Secret;
+import jakarta.inject.Inject;
 import java.net.URLEncoder;
-import javax.inject.Inject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.