### PR TITLE
Bump minimal Jenkins version to 2.426.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/webhook-step-plugin</gitHubRepo>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <spotbugs.threshold>High</spotbugs.threshold>
   </properties>
@@ -56,8 +56,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.414.x</artifactId>
-        <version>2982.vdce2153031a_0</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>3023.v02a_987a_b_3ff9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Plugin installation statistics show that 80% of the installations of 787.v665fcf2a_830b_ (6 months old) are already running Jenkins 2.426.3.

SECURITY-3314 advises users to upgrade to Jenkins 2.426.3 or newer to resolve a critical security vulnerability.

## Testing done
Relying on [ci.jenkins.io](http://ci.jenkins.io/) to run the tests.
