### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 
@@ -20,7 +20,7 @@
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 
@@ -48,8 +48,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/webhook-step-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.426</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <spotbugs.threshold>High</spotbugs.threshold>
   </properties>
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3208.vb_21177d4b_cd9</version>
+        <version>4136.vca_c3202a_7fd1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -76,15 +76,14 @@
       <artifactId>workflow-step-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit</artifactId>
       <version>2.40.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/RegisterWebhookExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/RegisterWebhookExecution.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.webhookstep;
 
 import hudson.util.Secret;
 import jakarta.inject.Inject;
+import java.io.Serial;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang.StringUtils;
@@ -10,7 +11,9 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
 
 public class RegisterWebhookExecution extends SynchronousStepExecution<WebhookToken> {
 
+    @Serial
     private static final long serialVersionUID = -6718328636399912927L;
+
     private final Secret secretAuthToken;
 
     @Inject

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WaitForWebhookExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WaitForWebhookExecution.java
@@ -1,11 +1,13 @@
 package org.jenkinsci.plugins.webhookstep;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Serial;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 public class WaitForWebhookExecution extends AbstractStepExecutionImpl {
 
+    @Serial
     private static final long serialVersionUID = -148119134567863021L;
 
     WaitForWebhookStep step;

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WaitForWebhookStep.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WaitForWebhookStep.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.webhookstep;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
@@ -14,6 +15,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 public class WaitForWebhookStep extends Step implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -667001655472658819L;
 
     private final String token;

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookResponse.java
@@ -1,11 +1,13 @@
 package org.jenkinsci.plugins.webhookstep;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 public class WebhookResponse implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1;
 
     private final String content;

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookRootAction.java
@@ -4,6 +4,10 @@ import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
 import hudson.util.Secret;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.CharBuffer;
@@ -11,12 +15,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.POST;
 
 @Extension
@@ -42,7 +42,7 @@ public class WebhookRootAction extends CrumbExclusion implements UnprotectedRoot
     }
 
     @POST
-    public void doDynamic(StaplerRequest request, StaplerResponse response) {
+    public void doDynamic(StaplerRequest2 request, StaplerResponse2 response) {
         String token = request.getOriginalRestOfPath().substring(1); // Strip leading slash
         String authHeader = request.getHeader("Authorization");
         Secret secretAuthToken;

--- a/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookToken.java
+++ b/src/main/java/org/jenkinsci/plugins/webhookstep/WebhookToken.java
@@ -1,11 +1,13 @@
 package org.jenkinsci.plugins.webhookstep;
 
 import hudson.util.Secret;
+import java.io.Serial;
 import java.io.Serializable;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 public class WebhookToken implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1;
 
     private final String token;


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Take `jackson2-api` from `bom`

### Testing done

Confirmed that tests pass.

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
